### PR TITLE
Separate HashKDF to a separate function with its own error message

### DIFF
--- a/userlib.go
+++ b/userlib.go
@@ -342,7 +342,23 @@ func hmacEval(key []byte, msg []byte) ([]byte, error) {
 
 var HMACEval = hmacEval
 
-// HashKDF (uses the same algorithm as hmacEval)
+// Equals comparison for hashes/MACs
+// Does NOT leak timing.
+func hmacEqual(a []byte, b []byte) bool {
+	return hmac.Equal(a, b)
+}
+
+var HMACEqual = hmacEqual
+
+/*
+********************************************
+**   Hash-Based Key Derivation Function   **
+**                 HashKDF                **
+********************************************
+ */
+
+// HashKDF (uses the same algorithm as hmacEval, wrapped to provide a useful
+// error)
 func hashKDF(key []byte, msg []byte) ([]byte, error) {
 	if len(key) != 16 && len(key) != 24 && len(key) != 32 {
 		panic(errors.New("The input as key for HashKDF should be a 16-byte key."))
@@ -355,14 +371,6 @@ func hashKDF(key []byte, msg []byte) ([]byte, error) {
 }
 
 var HashKDF = hashKDF
-
-// Equals comparison for hashes/MACs
-// Does NOT leak timing.
-func hmacEqual(a []byte, b []byte) bool {
-	return hmac.Equal(a, b)
-}
-
-var HMACEqual = hmacEqual
 
 /*
 ********************************************

--- a/userlib.go
+++ b/userlib.go
@@ -343,7 +343,7 @@ func hmacEval(key []byte, msg []byte) ([]byte, error) {
 var HMACEval = hmacEval
 
 // HashKDF (uses the same algorithm as hmacEval)
-func HashKDF(key []byte, msg []byte) ([]byte, error) {
+func hashKDF(key []byte, msg []byte) ([]byte, error) {
 	if len(key) != 16 && len(key) != 24 && len(key) != 32 {
 		panic(errors.New("The input as key for HashKDF should be a 16-byte key."))
 	}
@@ -353,6 +353,8 @@ func HashKDF(key []byte, msg []byte) ([]byte, error) {
 	res := mac.Sum(nil)
 	return res, nil
 }
+
+var HashKDF = hashKDF
 
 // Equals comparison for hashes/MACs
 // Does NOT leak timing.

--- a/userlib.go
+++ b/userlib.go
@@ -342,7 +342,17 @@ func hmacEval(key []byte, msg []byte) ([]byte, error) {
 
 var HMACEval = hmacEval
 
-var HashKDF = hmacEval
+// HashKDF (uses the same algorithm as hmacEval)
+func HashKDF(key []byte, msg []byte) ([]byte, error) {
+	if len(key) != 16 && len(key) != 24 && len(key) != 32 {
+		panic(errors.New("The input as key for HashKDF should be a 16-byte key."))
+	}
+
+	mac := hmac.New(sha512.New, key)
+	mac.Write(msg)
+	res := mac.Sum(nil)
+	return res, nil
+}
 
 // Equals comparison for hashes/MACs
 // Does NOT leak timing.


### PR DESCRIPTION
When you call HashKDF with a non-16 byte key, you see "The input as key for HMAC should be a 16-byte key." which is extremely unintuitive