### PR TITLE
Use sync.Map for datastore/keystore sharding

### DIFF
--- a/userlib_test.go
+++ b/userlib_test.go
@@ -174,9 +174,9 @@ var _ = Describe("Client Tests", func() {
 		Describe("KeystoreGetMap()", func() {
 			It("should return the underlying map", func() {
 				pid := CurrentSpecReport().LineNumber()
-				keystorePrologue(pid)
 				actualPtr := reflect.ValueOf(KeystoreGetMap()).Pointer()
-				expectedPtr := reflect.ValueOf(keystore[pid]).Pointer()
+				keystoreShard, _ := keystore.Load(pid)
+				expectedPtr := reflect.ValueOf(keystoreShard).Pointer()
 				Expect(actualPtr).To(Equal(expectedPtr),
 					"The map returned was not the underlying keystore map.")
 			})


### PR DESCRIPTION
As far as I know, we had concurrency issues when running tests in parallel since the userlib has a single, global map for the “datastore shards,” which would be accessed in parallel by the parallel test cases in Ginkgo. Adding a `sync.Map` instead of a Golang native map resolves this.